### PR TITLE
Chore: Initialize repository baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+.idea
+dump.rdb
+node_modules
+npm-debug.log
+.DS_Store
+public/*
+public/.gitkeep
+po/*.pot
+Thumbs.db
+logs
+.vscode
+config.jsonc
+config.test.jsonc
+
+# ai
+.ai-ignored/
+.ai-tasks/
+.claude/

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,10 @@
+{
+  "MD013": false,
+  "MD029": false,
+  "MD024": { "siblings_only": true },
+  "MD041": false,
+  "MD060": false,
+  "MD040": false,
+  "MD036": false,
+  "MD034": false
+}


### PR DESCRIPTION
## Description

Initialize the repository with baseline hygiene files required before website implementation.

Changes in this PR:

- **`.gitignore`** — ignore Node.js dependencies, IDE/editor files, OS artifacts, logs, local config overrides (`config.jsonc`, `config.test.jsonc`), generated `public/*` assets (keeping `public/.gitkeep`), and AI working directories (`.ai-ignored/`, `.ai-tasks/`, `.claude/`)
- **`.markdownlint.jsonc`** — shared markdown lint configuration with pragmatic rule overrides (line length, duplicate headings siblings-only, etc.)

No application code, framework setup, or website content is included.

## Related issue

Closes #3

## How to test

- [ ] Confirm `.gitignore` and `.markdownlint.jsonc` are present at repository root
- [ ] Create local `node_modules/`, `.ai-ignored/test.txt`, and `config.jsonc` — verify they are ignored by `git status`
- [ ] Run markdown lint against `README.md` if a linter is available locally
- [ ] Confirm `README.md` and `LICENSE` are unchanged

## Checklist

- [x] `.gitignore` added with Node.js, IDE, config, and AI directory exclusions
- [x] `.markdownlint.jsonc` added with org-aligned overrides
- [x] No secrets or environment-specific configuration committed
- [x] Issue linked with closing keyword

## Notes

Issue: https://github.com/Adamant-im/adamant.business-website/issues/3

Separate follow-up: #1 (`AGENTS.md` on `docs/agents-md` branch)
