### PR TITLE
Fix: Make content PR recovery and admin merge reliable

### DIFF
--- a/scripts/lib/github-publishing.mjs
+++ b/scripts/lib/github-publishing.mjs
@@ -64,7 +64,41 @@ export function contentBranchSwitchArgs(branchName, startPoint = 'origin/master'
   return ['switch', '--force-create', branchName, startPoint];
 }
 
-export async function assertPublishingReady() {
+export function pullRequestMergeArgs(prUrl, publisherPermission) {
+  return [
+    'pr',
+    'merge',
+    prUrl,
+    '--squash',
+    '--delete-branch',
+    ...(publisherPermission === 'ADMIN' ? ['--admin'] : []),
+  ];
+}
+
+export function selectOwnedOpenPullRequest(pullRequests, branchName, publisher) {
+  if (!branchName.startsWith('content/')) {
+    throw new Error(`Refusing to inspect a non-content branch: ${branchName}`);
+  }
+
+  const matching = pullRequests.filter(
+    (pullRequest) =>
+      pullRequest.baseRefName === 'master' && pullRequest.headRefName === branchName,
+  );
+  if (matching.length > 1) {
+    throw new Error(`Multiple open PRs found for automation branch ${branchName}`);
+  }
+  if (matching.length === 0) return null;
+
+  const pullRequest = matching[0];
+  if (pullRequest.author?.login !== publisher) {
+    throw new Error(
+      `Refusing to reuse PR not created by the current publisher: author=${pullRequest.author?.login}, head=${pullRequest.headRefName}, base=${pullRequest.baseRefName}`,
+    );
+  }
+  return pullRequest;
+}
+
+export async function assertPublishingReady({ requireAdminMerge = false } = {}) {
   const status = await run('git', ['status', '--porcelain'], { capture: true });
   if (status.stdout) {
     throw new Error('PR mode requires a clean working tree; use --no-pr for local generation');
@@ -79,10 +113,16 @@ export async function assertPublishingReady() {
   if (!['ADMIN', 'MAINTAIN', 'WRITE'].includes(repository.viewerPermission)) {
     throw new Error(`GitHub ${repository.viewerPermission} permission cannot publish content PRs`);
   }
+  if (requireAdminMerge && repository.viewerPermission !== 'ADMIN') {
+    throw new Error(
+      `Automatic content merge requires GitHub ADMIN permission; current permission is ${repository.viewerPermission}. Use --no-merge or an ADMIN token`,
+    );
+  }
   if (!repository.squashMergeAllowed) throw new Error('Repository does not allow squash merges');
   console.log(
-    `GitHub publication access: ${repository.nameWithOwner} (${repository.viewerPermission}, squash merge enabled)`,
+    `GitHub publication access: ${repository.nameWithOwner} (${repository.viewerPermission}, squash merge enabled${requireAdminMerge ? ', admin bypass enabled' : ''})`,
   );
+  return repository;
 }
 
 export async function validateGeneratedContent({ contentChanged = true } = {}) {
@@ -117,7 +157,41 @@ async function assertCreatedPullRequest(prUrl, branchName) {
     author !== publisher.stdout
   ) {
     throw new Error(
-      `Refusing to merge PR not created by this run: author=${author}, head=${details.headRefName}, base=${details.baseRefName}`,
+      `Refusing to merge PR not owned by the current content publisher: author=${author}, head=${details.headRefName}, base=${details.baseRefName}`,
+    );
+  }
+}
+
+async function findOwnedOpenPullRequest(branchName) {
+  const [publisher, pullRequests] = await Promise.all([
+    run('gh', ['api', 'user', '--jq', '.login'], { capture: true }),
+    run(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--state',
+        'open',
+        '--base',
+        'master',
+        '--head',
+        branchName,
+        '--json',
+        'author,baseRefName,headRefName,url',
+      ],
+      { capture: true },
+    ),
+  ]);
+  return selectOwnedOpenPullRequest(JSON.parse(pullRequests.stdout), branchName, publisher.stdout);
+}
+
+async function mergeOwnedPullRequest(prUrl, branchName, publisherPermission) {
+  try {
+    await assertCreatedPullRequest(prUrl, branchName);
+    await run('gh', pullRequestMergeArgs(prUrl, publisherPermission));
+  } catch (error) {
+    throw new Error(
+      `${error.message}. Automatic content merge requires an ADMIN token and uses an explicit administrative bypass`,
     );
   }
 }
@@ -144,6 +218,7 @@ export async function publishChange({
   branchName,
   commitMessage,
   noMerge,
+  publisherPermission,
   prBody,
   prTitle,
   generate,
@@ -154,12 +229,33 @@ export async function publishChange({
   let merged = false;
   let prUrl = null;
 
+  if (!noMerge && publisherPermission !== 'ADMIN') {
+    throw new Error(
+      `Automatic content merge requires GitHub ADMIN permission; received ${publisherPermission || 'no permission'}`,
+    );
+  }
+
   await run('git', ['fetch', 'origin', 'master']);
   const remoteBranch = await run('git', ['ls-remote', '--exit-code', '--heads', 'origin', branchName], {
     capture: true,
     allowExitCodes: [0, 2],
   });
-  if (remoteBranch.code === 0) throw new Error(`Remote branch already exists: ${branchName}`);
+  if (remoteBranch.code === 0) {
+    const existingPullRequest = await findOwnedOpenPullRequest(branchName);
+    if (existingPullRequest) {
+      prUrl = existingPullRequest.url;
+      console.log(`Resuming existing automation PR ${prUrl}`);
+      if (noMerge) return { prUrl, merged: false, resumed: true };
+      await mergeOwnedPullRequest(prUrl, branchName, publisherPermission);
+      merged = true;
+      console.log(`Merged ${prUrl}`);
+      await restoreStartingPoint(startingBranch, startingSha, branchName, merged);
+      return { prUrl, merged, resumed: true };
+    }
+
+    console.log(`Deleting stale remote automation branch ${branchName}`);
+    await run('git', ['push', 'origin', '--delete', branchName]);
+  }
   await run('git', contentBranchSwitchArgs(branchName));
 
   try {
@@ -213,14 +309,7 @@ export async function publishChange({
     console.log(`Created ${prUrl}`);
 
     if (!noMerge) {
-      try {
-        await assertCreatedPullRequest(prUrl, branchName);
-        await run('gh', ['pr', 'merge', prUrl, '--squash', '--delete-branch']);
-      } catch (error) {
-        throw new Error(
-          `${error.message}. Direct squash merge is available with WRITE access because master currently has no approval rule; if repository rules changed, use --no-merge or an ADMIN token.`,
-        );
-      }
+      await mergeOwnedPullRequest(prUrl, branchName, publisherPermission);
       merged = true;
       console.log(`Merged ${prUrl}`);
     }

--- a/scripts/remove-content.mjs
+++ b/scripts/remove-content.mjs
@@ -37,11 +37,12 @@ export async function removeContent(options = parseRemoveOptions(process.argv.sl
     return result;
   }
 
-  await assertPublishingReady();
+  const publishing = await assertPublishingReady({ requireAdminMerge: !options.noMerge });
   return publishChange({
     branchName: removalBranchName({ category: classified?.type, slug: branchSlug }),
     commitMessage: `Remove engineering note: ${branchSlug}`.slice(0, 200),
     noMerge: options.noMerge,
+    publisherPermission: publishing.viewerPermission,
     prTitle: `Remove content: ${branchSlug}`.slice(0, 250),
     prBody: (result) => removalPrBody(result),
     generate: () => removePublication({ slug: options.slug, url: selector.sourceUrl }),

--- a/scripts/sync-content.mjs
+++ b/scripts/sync-content.mjs
@@ -70,13 +70,14 @@ export async function syncContent(options = parseSyncOptions(process.argv.slice(
       console.log('Generated content is unchanged; skipping validation and build');
     }
   } else {
-    await assertPublishingReady();
+    const publishing = await assertPublishingReady({ requireAdminMerge: !options.noMerge });
     for (const publication of candidates) {
       results.push(
         await publishChange({
           branchName: additionBranchName(publication),
           commitMessage: `Add ${publication.category}: ${publication.title}`.slice(0, 200),
           noMerge: options.noMerge,
+          publisherPermission: publishing.viewerPermission,
           prBody: additionPrBody(publication),
           prTitle: additionPrTitle(publication),
           generate: () => generatePublication(publication, { saveOriginalSource }),

--- a/scripts/tests/github-publishing.test.mjs
+++ b/scripts/tests/github-publishing.test.mjs
@@ -6,7 +6,11 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import test from 'node:test';
 
-import { contentBranchSwitchArgs } from '../lib/github-publishing.mjs';
+import {
+  contentBranchSwitchArgs,
+  pullRequestMergeArgs,
+  selectOwnedOpenPullRequest,
+} from '../lib/github-publishing.mjs';
 
 const exec = promisify(execFile);
 
@@ -48,5 +52,49 @@ test('refuses to force-recreate a branch outside the content namespace', () => {
   assert.throws(
     () => contentBranchSwitchArgs('master'),
     /Refusing to overwrite a non-content branch/,
+  );
+});
+
+test('uses an explicit administrative bypass for ADMIN content publishers', () => {
+  const prUrl = 'https://github.com/Adamant-im/adamant.business-website/pull/20';
+
+  assert.deepEqual(pullRequestMergeArgs(prUrl, 'ADMIN'), [
+    'pr',
+    'merge',
+    prUrl,
+    '--squash',
+    '--delete-branch',
+    '--admin',
+  ]);
+  assert.deepEqual(pullRequestMergeArgs(prUrl, 'WRITE'), [
+    'pr',
+    'merge',
+    prUrl,
+    '--squash',
+    '--delete-branch',
+  ]);
+});
+
+test('resumes only an open content PR owned by the current publisher', () => {
+  const branchName = 'content/retry-publication';
+  const pullRequest = {
+    author: { login: 'dev-adamant-im' },
+    baseRefName: 'master',
+    headRefName: branchName,
+    url: 'https://github.com/Adamant-im/adamant.business-website/pull/20',
+  };
+
+  assert.equal(
+    selectOwnedOpenPullRequest([pullRequest], branchName, 'dev-adamant-im'),
+    pullRequest,
+  );
+  assert.equal(selectOwnedOpenPullRequest([], branchName, 'dev-adamant-im'), null);
+  assert.throws(
+    () => selectOwnedOpenPullRequest([pullRequest], branchName, 'another-publisher'),
+    /Refusing to reuse PR not created by the current publisher/,
+  );
+  assert.throws(
+    () => selectOwnedOpenPullRequest([pullRequest, pullRequest], branchName, 'dev-adamant-im'),
+    /Multiple open PRs found/,
   );
 });


### PR DESCRIPTION
## Description

Make automated Engineering notes publishing recover safely from an interrupted merge and use the repository's configured administrative bypass explicitly.

The pipeline now:

- Requires `ADMIN` permission before an automatic merge
- Calls `gh pr merge` with `--admin` for approval and Code Owner bypass
- Resumes an existing open `content/*` PR owned by the authenticated publisher
- Deletes an orphaned automation branch only when no open PR uses it
- Refuses to reuse or merge a PR owned by another publisher

## Root cause

The `master` branch requires one approval and a Code Owner review. The Actions token belongs to `dev-adamant-im`, which has `ADMIN` permission and is listed in the bypass allowances, but the pipeline called `gh pr merge` without `--admin`. GitHub rejected the merge after content generation and PR creation, leaving the PR and its remote branch open.

## Related issue

- Related to #11
- Failed run: https://github.com/Adamant-im/adamant.business-website/actions/runs/29731964063
- Recovery target: #20

## How to test

- Run `npm run test:content`
- Run `npm run validate:config`
- Run `npm run validate:notes`
- Run `npm run lint`
- Run `npm run build`
- Run `npm run validate:seo`
- Run `npm run sync:content -- --url https://news.adamant.im/a-clearer-view-of-adamant-redesigned-blockchain-explorer-f97501b0dc55 --no-merge`
- Confirm the retry reports PR #20 without regenerating content or changing the working tree

## Security and risk review

Administrative bypass is available only when GitHub reports `ADMIN` permission. Before every merge, the pipeline verifies the PR URL, `master` base, deterministic `content/*` head branch, and current authenticated publisher. Foreign PRs are rejected.

The recovery path can delete only an orphaned branch in the automation-owned `content/*` namespace. It does not overwrite arbitrary branches.

## Checklist

- [x] Regression tests cover explicit admin merge arguments
- [x] Regression tests cover publisher ownership and duplicate PR rejection
- [x] Existing local stale-branch protection remains enabled
- [x] Full content, Astro, build, and SEO validation passed
- [x] No secrets or private configuration are included
