### PR TITLE
Fix: Retry invalid translations with the next model

### DIFF
--- a/scripts/lib/markdown-safety.mjs
+++ b/scripts/lib/markdown-safety.mjs
@@ -35,5 +35,5 @@ export function codePlaceholderIssue(body, blockCount) {
 }
 
 export function hasUnresolvedCodePlaceholder(body) {
-  return /@@CODEBLOCK(?:\d+|n)@@/.test(String(body));
+  return /@@\s*CODEBLOCK[^@\n]*@@/i.test(String(body));
 }

--- a/scripts/lib/translate-content.mjs
+++ b/scripts/lib/translate-content.mjs
@@ -83,20 +83,44 @@ function needsRetranslation(englishBody, translatedBody) {
   return unchanged.length / englishProse.length > 0.5;
 }
 
-function buildTranslationPrompt({ localeId, localeLabel, category, frontmatter, body, strict = false }) {
+export function buildCodePlaceholderRequirements(blockCount) {
+  if (blockCount === 0) {
+    return '- The input contains no protected code block placeholders; do not invent or add any placeholder tokens';
+  }
+
+  const placeholders = Array.from(
+    { length: blockCount },
+    (_, index) => `@@CODEBLOCK${index}@@`,
+  );
+
+  return [
+    `- Preserve each of these protected code block placeholders exactly once: ${placeholders.join(', ')}`,
+    '- Do not add, remove, duplicate, rename, or translate the listed placeholders',
+  ].join('\n');
+}
+
+function buildTranslationPrompt({
+  localeId,
+  localeLabel,
+  category,
+  frontmatter,
+  body,
+  blockCount,
+  retryReason = '',
+}) {
   const categoryHint = CATEGORY_HINTS[category]?.(localeLabel) ?? '';
-  const strictNote = strict
-    ? `\nIMPORTANT: Your previous attempt left English text in the body. Translate EVERY sentence and heading into ${localeLabel}. Only glossary terms, code placeholders, URLs, and inline code stay in English.\n`
+  const retryNote = retryReason
+    ? `\nIMPORTANT: Previous output failed validation: ${retryReason}. Correct this failure. Translate EVERY sentence and heading into ${localeLabel}. Only glossary terms, protected code blocks, URLs, and inline code stay in English.\n`
     : '';
 
   return `Translate this engineering note from English to ${localeLabel} (${localeId}).
-${strictNote}
+${retryNote}
 Quality requirements:
 - Natural, fluent, grammatically correct ${localeLabel} for a technical audience
 - Preserve meaning; do not add or remove facts
 - The "body" field must be fully translated into ${localeLabel} — not a mix of English and ${localeLabel}
 - Keep Markdown structure: headings, paragraphs, bold, links, tables
-- Keep @@CODEBLOCKn@@ placeholders EXACTLY as they appear — do not translate or remove them
+${buildCodePlaceholderRequirements(blockCount)}
 - Keep inline code, URLs, file paths, image paths, and HTML tags unchanged
 - Translate image alt text and visible prose; translate ALL headings including ## and ###
 - description: max 180 characters, one line, plain text, no markdown
@@ -182,7 +206,12 @@ function normalizeBrands(text) {
   return BRAND_FIXES.reduce((value, [pattern, replacement]) => value.replace(pattern, replacement), text);
 }
 
-export async function translateNoteToLocale(englishFrontmatter, body, localeId) {
+export async function translateNoteToLocale(
+  englishFrontmatter,
+  body,
+  localeId,
+  { requestOpenRouter = callOpenRouter } = {},
+) {
   const locale = siteConfig.locales.find((item) => item.id === localeId);
   if (!locale) throw new Error(`Unknown locale: ${localeId}`);
   if (localeId === siteConfig.defaultLocale) {
@@ -193,20 +222,21 @@ export async function translateNoteToLocale(englishFrontmatter, body, localeId) 
   const { protectedBody, blocks } = protectCodeBlocks(normalizedEnglishBody);
   const localeLabel = LOCALE_NAMES[localeId] ?? locale.label;
 
-  async function requestTranslation(strict = false) {
+  async function requestTranslation(configuredModel, retryReason = '') {
     const prompt = buildTranslationPrompt({
       localeId,
       localeLabel,
       category: englishFrontmatter.category,
       frontmatter: englishFrontmatter,
       body: protectedBody,
-      strict,
+      blockCount: blocks.length,
+      retryReason,
     });
 
     const translate = siteConfig.openRouter.translate;
 
-    const { data: translated, model } = await callOpenRouter(prompt, {
-      models: translate.models,
+    const { data: translated, model } = await requestOpenRouter(prompt, {
+      models: [configuredModel],
       temperature: translate.temperature,
       maxTokens: translate.maxTokens,
       timeoutMs: translate.timeoutMs,
@@ -214,14 +244,10 @@ export async function translateNoteToLocale(englishFrontmatter, body, localeId) 
       provider: translate.provider,
       title: 'cryptofoundry content translation',
       system:
-        'You are a professional technical translator for a crypto engineering blog. Output strict JSON with title, description, and body fields. The body must be fully translated into the target language. Never translate glossary terms or code placeholders.',
+        `You are a professional technical translator for a crypto engineering blog. Output strict JSON with title, description, and body fields. The body must be fully translated into the target language. Never translate glossary terms${blocks.length > 0 ? ' or the listed protected code blocks' : ''}.`,
     });
 
-    if (!translated?.title || !translated?.body) {
-      throw new Error(`Invalid translation response for ${englishFrontmatter.slug} → ${localeId}`);
-    }
-
-    return { translated, model };
+    return { translated, model: model ?? configuredModel };
   }
 
   function restoreValidatedBody(translatedBody) {
@@ -234,28 +260,77 @@ export async function translateNoteToLocale(englishFrontmatter, body, localeId) 
     return restored;
   }
 
-  let { translated, model } = await requestTranslation(false);
+  const translate = siteConfig.openRouter.translate;
+  const configuredModels = [...translate.models];
+  const attemptedModels = [];
+  let translated;
+  let model;
   let restoredBody;
   let retryReason = '';
+  let lastFailureReason = '';
 
-  try {
-    restoredBody = restoreValidatedBody(translated.body);
-    if (needsRetranslation(normalizedEnglishBody, restoredBody)) {
-      retryReason = 'body still contains English prose';
+  for (const [index, configuredModel] of configuredModels.entries()) {
+    const fallbackModel = configuredModels[index + 1];
+
+    try {
+      ({ translated, model } = await requestTranslation(configuredModel, retryReason));
+    } catch (error) {
+      if (/OpenRouter account error/.test(error.message)) throw error;
+      lastFailureReason = `request failed: ${error.message}`;
+      attemptedModels.push(configuredModel);
+      console.warn(
+        `Translation request ${englishFrontmatter.slug} → ${localeId} failed via ${configuredModel}: ${error.message}${fallbackModel ? `; retrying with ${fallbackModel}` : ''}`,
+      );
+      continue;
     }
-  } catch (error) {
-    retryReason = error.message;
+
+    attemptedModels.push(configuredModel);
+
+    try {
+      if (typeof translated?.title !== 'string' || translated.title.trim() === '') {
+        throw new Error('response title must be a non-empty string');
+      }
+      if (typeof translated?.body !== 'string' || translated.body.trim() === '') {
+        throw new Error('response body must be a non-empty string');
+      }
+      if (
+        translated.description !== undefined &&
+        translated.description !== null &&
+        typeof translated.description !== 'string'
+      ) {
+        throw new Error('response description must be a string when provided');
+      }
+      for (const [field, value] of [
+        ['title', translated.title],
+        ['description', translated.description ?? ''],
+      ]) {
+        const issue = codePlaceholderIssue(value, 0);
+        if (issue) throw new Error(`response ${field} contains a code placeholder: ${issue}`);
+        if (hasUnresolvedCodePlaceholder(value)) {
+          throw new Error(`response ${field} contains an unresolved code placeholder`);
+        }
+      }
+
+      restoredBody = restoreValidatedBody(translated.body);
+      if (needsRetranslation(normalizedEnglishBody, restoredBody)) {
+        throw new Error('body still contains English prose');
+      }
+      break;
+    } catch (error) {
+      retryReason = error.message;
+      lastFailureReason = retryReason;
+      console.warn(
+        `Rejected translation ${englishFrontmatter.slug} → ${localeId} via ${model}: ${retryReason}${fallbackModel ? `; retrying with ${fallbackModel}` : ''}`,
+      );
+      translated = undefined;
+      restoredBody = undefined;
+    }
   }
 
-  if (retryReason) {
-    console.warn(
-      `Retranslating ${englishFrontmatter.slug} → ${localeId}: ${retryReason}`,
+  if (!translated || restoredBody === undefined) {
+    throw new Error(
+      `Translation failed for ${englishFrontmatter.slug} → ${localeId} after ${attemptedModels.join(', ')}: ${lastFailureReason}`,
     );
-    ({ translated, model } = await requestTranslation(true));
-    restoredBody = restoreValidatedBody(translated.body);
-    if (needsRetranslation(normalizedEnglishBody, restoredBody)) {
-      throw new Error(`Translation still contains English prose for ${englishFrontmatter.slug} → ${localeId}`);
-    }
   }
 
   console.log(`Translated ${englishFrontmatter.slug} → ${localeId} via ${model}`);
@@ -264,7 +339,9 @@ export async function translateNoteToLocale(englishFrontmatter, body, localeId) 
     ...englishFrontmatter,
     title: normalizeBrands(translated.title),
     description: normalizeBrands(
-      translated.description ?? markdownExcerpt(restoredBody, translated.title),
+      translated.description?.trim()
+        ? translated.description
+        : markdownExcerpt(restoredBody, translated.title),
     ),
     locale: localeId,
     placeholder: false,

--- a/scripts/tests/markdown-safety.test.mjs
+++ b/scripts/tests/markdown-safety.test.mjs
@@ -17,6 +17,7 @@ test('normalizes malformed literal newline code fences from model output', () =>
 
 test('requires each protected code block placeholder exactly once', () => {
   assert.equal(codePlaceholderIssue('@@CODEBLOCK0@@\n@@CODEBLOCK1@@', 2), null);
+  assert.match(codePlaceholderIssue('@@CODEBLOCK0@@', 0), /unknown 0/);
   assert.match(codePlaceholderIssue('@@CODEBLOCK1@@', 2), /missing 0/);
   assert.match(codePlaceholderIssue('@@CODEBLOCK0@@\n@@CODEBLOCK2@@', 2), /unknown 2/);
   assert.match(codePlaceholderIssue('@@CODEBLOCK0@@\n@@CODEBLOCK0@@', 1), /duplicated 0/);
@@ -26,4 +27,7 @@ test('detects unresolved numeric and malformed placeholders', () => {
   assert.equal(hasUnresolvedCodePlaceholder('Clean body'), false);
   assert.equal(hasUnresolvedCodePlaceholder('@@CODEBLOCK3@@'), true);
   assert.equal(hasUnresolvedCodePlaceholder('@@CODEBLOCKn@@'), true);
+  assert.equal(hasUnresolvedCodePlaceholder('@@CODEBLOCKN@@'), true);
+  assert.equal(hasUnresolvedCodePlaceholder('@@CODEBLOCK_0@@'), true);
+  assert.equal(hasUnresolvedCodePlaceholder('@@codeblock0@@'), true);
 });

--- a/scripts/tests/translate-content.test.mjs
+++ b/scripts/tests/translate-content.test.mjs
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildCodePlaceholderRequirements,
+  translateNoteToLocale,
+} from '../lib/translate-content.mjs';
+
+const frontmatter = {
+  title: 'English title',
+  description: 'English description',
+  slug: 'translation-fallback-test',
+  category: 'discussion',
+  publishedAt: '2026-07-20T00:00:00.000Z',
+  author: 'cryptofoundry',
+  sourceUrl: 'https://example.com/source',
+  originalId: 'test:translation-fallback',
+};
+
+const englishBody = 'First English paragraph.\n\nSecond English paragraph.';
+
+function validRussianTranslation(body = 'Первый абзац.\n\nВторой абзац.') {
+  return {
+    title: 'Русский заголовок',
+    description: 'Русское описание',
+    body,
+  };
+}
+
+test('does not mention code placeholder tokens when the source has no code blocks', async () => {
+  const calls = [];
+  const requestOpenRouter = async (prompt, options) => {
+    calls.push({ prompt, options });
+    return { data: validRussianTranslation(), model: options.models[0] };
+  };
+
+  const translated = await translateNoteToLocale(frontmatter, englishBody, 'ru', {
+    requestOpenRouter,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].options.models, ['qwen/qwen3.7-plus']);
+  assert.doesNotMatch(calls[0].prompt, /@@CODEBLOCK/);
+  assert.doesNotMatch(calls[0].options.system, /@@CODEBLOCK/);
+  assert.match(translated, /Русский заголовок/);
+  assert.match(translated, /Первый абзац/);
+});
+
+test('uses the next configured model after a semantic placeholder failure', async () => {
+  const calls = [];
+  const requestOpenRouter = async (prompt, options) => {
+    calls.push({ prompt, options });
+    const data = calls.length === 1
+      ? validRussianTranslation('Русский текст.\n\n@@CODEBLOCK0@@')
+      : validRussianTranslation();
+    return { data, model: options.models[0] };
+  };
+
+  const translated = await translateNoteToLocale(frontmatter, englishBody, 'ru', {
+    requestOpenRouter,
+  });
+
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0].options.models, ['qwen/qwen3.7-plus']);
+  assert.deepEqual(calls[1].options.models, ['deepseek/deepseek-v4-pro']);
+  assert.match(calls[1].prompt, /Previous output failed validation: Code placeholder mismatch: unknown 0/);
+  assert.doesNotMatch(translated, /@@CODEBLOCK/);
+});
+
+test('preserves the semantic retry reason across an intermediate transport failure', async () => {
+  const calls = [];
+  const requestOpenRouter = async (prompt, options) => {
+    calls.push({ prompt, options });
+    if (calls.length === 1) {
+      return {
+        data: validRussianTranslation('Русский текст.\n\n@@CODEBLOCK0@@'),
+        model: options.models[0],
+      };
+    }
+    if (calls.length === 2) {
+      throw new Error('OpenRouter failed after 2 attempts: timeout');
+    }
+    return { data: validRussianTranslation(), model: options.models[0] };
+  };
+
+  const translated = await translateNoteToLocale(frontmatter, englishBody, 'ru', {
+    requestOpenRouter,
+  });
+
+  assert.equal(calls.length, 3);
+  assert.deepEqual(calls[2].options.models, ['qwen/qwen3-235b-a22b-2507']);
+  assert.match(calls[2].prompt, /Previous output failed validation: Code placeholder mismatch: unknown 0/);
+  assert.match(translated, /Первый абзац/);
+});
+
+test('rejects internal placeholders in translated frontmatter fields', async () => {
+  const calls = [];
+  const requestOpenRouter = async (_prompt, options) => {
+    calls.push(options.models[0]);
+    const data = calls.length === 1
+      ? { ...validRussianTranslation(), title: 'Заголовок @@codeblock_0@@' }
+      : validRussianTranslation();
+    return { data, model: options.models[0] };
+  };
+
+  const translated = await translateNoteToLocale(frontmatter, englishBody, 'ru', {
+    requestOpenRouter,
+  });
+
+  assert.deepEqual(calls, ['qwen/qwen3.7-plus', 'deepseek/deepseek-v4-pro']);
+  assert.doesNotMatch(translated, /@@codeblock/i);
+});
+
+test('lists exact placeholders and restores protected code blocks unchanged', async () => {
+  const source = 'Before the example.\n\n```js\nconst value = 1;\n```\n\nAfter the example.';
+  let capturedPrompt = '';
+  const requestOpenRouter = async (prompt, options) => {
+    capturedPrompt = prompt;
+    return {
+      data: validRussianTranslation('До примера.\n\n@@CODEBLOCK0@@\n\nПосле примера.'),
+      model: options.models[0],
+    };
+  };
+
+  const translated = await translateNoteToLocale(frontmatter, source, 'ru', {
+    requestOpenRouter,
+  });
+
+  assert.match(capturedPrompt, /Preserve each of these protected code block placeholders exactly once: @@CODEBLOCK0@@/);
+  assert.match(translated, /```js\nconst value = 1;\n```/);
+  assert.doesNotMatch(translated, /@@CODEBLOCK/);
+});
+
+test('reports every attempted model when all translations fail validation', async () => {
+  const models = [];
+  const requestOpenRouter = async (_prompt, options) => {
+    models.push(options.models[0]);
+    return {
+      data: { title: 42, description: 'Description', body: 'Переведённый текст.' },
+      model: options.models[0],
+    };
+  };
+
+  await assert.rejects(
+    translateNoteToLocale(frontmatter, englishBody, 'ru', { requestOpenRouter }),
+    /Translation failed for translation-fallback-test → ru after qwen\/qwen3\.7-plus, deepseek\/deepseek-v4-pro, qwen\/qwen3-235b-a22b-2507: response title must be a non-empty string/,
+  );
+  assert.deepEqual(models, [
+    'qwen/qwen3.7-plus',
+    'deepseek/deepseek-v4-pro',
+    'qwen/qwen3-235b-a22b-2507',
+  ]);
+});
+
+test('does not try another model after an OpenRouter account error', async () => {
+  let callCount = 0;
+  const requestOpenRouter = async () => {
+    callCount += 1;
+    throw new Error('OpenRouter account error (402: insufficient balance)');
+  };
+
+  await assert.rejects(
+    translateNoteToLocale(frontmatter, englishBody, 'ru', { requestOpenRouter }),
+    /OpenRouter account error/,
+  );
+  assert.equal(callCount, 1);
+});
+
+test('builds a precise placeholder rule for every protected block', () => {
+  assert.doesNotMatch(buildCodePlaceholderRequirements(0), /@@CODEBLOCK/);
+  assert.match(
+    buildCodePlaceholderRequirements(2),
+    /@@CODEBLOCK0@@, @@CODEBLOCK1@@/,
+  );
+});


### PR DESCRIPTION
## Description

- Keep `qwen/qwen3.7-plus` as the primary translation model
- Retry semantic validation failures with the next configured model instead of requesting the same model again
- Give fallback models the actual validation reason and exact allowed code block placeholders
- Avoid showing placeholder syntax when an English source contains no code blocks
- Reject placeholder leakage in translated bodies, titles, and descriptions, including malformed and case-variant markers
- Preserve immediate failure for OpenRouter account errors while allowing model-specific transport failures to advance to the next model
- Add regression coverage for semantic fallback, transport fallback, placeholder restoration, invalid response types, and exhausted model lists

## Root cause

The translation prompt always included the literal `@@CODEBLOCKn@@` marker even when a source had no code blocks. When qwen copied or invented that marker, the semantic retry sent the same complete model list with qwen first, so the invalid result could repeat instead of advancing to DeepSeek.

## Related issue

- Related to #11
- Fixes the failure observed in [scheduled content sync run 29815562377](https://github.com/Adamant-im/adamant.business-website/actions/runs/29815562377)

## How to test

```bash
npm run lint
npm run validate:config
npm run test:content
npm run validate:notes
npm run build
npm run validate:seo
git diff --check
```

## Risk review

- OpenRouter request settings, temperature, and model priority remain unchanged
- Additional model requests occur only after a transport or semantic validation failure
- Account and billing errors still stop immediately
- No secrets, public copy, content records, or deployment settings are changed

## Checklist

- [x] Repository artifacts are in English
- [x] Translation validation remains strict
- [x] Regression tests cover the failed scheduled-run scenario
- [x] Lint completes with zero diagnostics
- [x] Content, config, notes, build, and SEO validation pass
