### PR TITLE
Feat: Improve automated translation quality

### DIFF
--- a/config/site.ts
+++ b/config/site.ts
@@ -88,9 +88,9 @@ export const siteConfig = {
       },
     },
     translate: {
-      models: ['qwen/qwen3.7-plus', 'deepseek/deepseek-v4-pro', 'qwen/qwen3-235b-a22b-2507'],
+      models: ['google/gemini-3.1-flash-lite', 'qwen/qwen3.7-plus', 'deepseek/deepseek-v4-pro'],
       maxTokens: 12000,
-      temperature: 0.3,
+      temperature: 0.4,
       timeoutMs: 180_000,
       maxAttempts: 2,
       provider: {

--- a/scripts/lib/translate-content.mjs
+++ b/scripts/lib/translate-content.mjs
@@ -30,9 +30,22 @@ const GLOSSARY = `Glossary — keep exact spelling, do not translate:
 - Packages and paths: adamant-tradebot, config.default.jsonc, modules/commands/
 - Telegram handle: @adamant_business`;
 
-const TITLE_EXAMPLE = `Title translation example:
-English: "ADAMANT Tradebot v9.0.0"
-Good German: "ADAMANT Tradebot v9.0.0" (keep product name; translate only if grammar requires surrounding words)`;
+const EDITORIAL_REQUIREMENTS = `Translation and editorial workflow:
+1. First understand the complete source, its technical meaning, factual relationships, scope, and level of certainty.
+2. Translate the meaning into the target language without following English syntax or word order mechanically.
+3. Edit the translation into publication-ready prose that reads as if it were originally written by a native technical writer in the target language.
+4. Silently compare the edited translation with the source and correct any changed, added, weakened, or omitted meaning before responding.
+
+Universal editorial requirements:
+- Use natural target-language syntax, idiomatic collocations, established technical terminology, and a consistent professional register.
+- Prefer clear verbs and direct sentences over awkward noun chains, excessive passive voice, and source-language constructions.
+- Avoid calques, unnecessary transliteration, redundant wording, mixed-language prose, and explanations in parentheses unless the source contains them or the English term is genuinely conventional in the target language.
+- Translate technical prose naturally, but preserve product names, API identifiers, code, paths, URLs, Markdown syntax, and glossary terms exactly as required.
+- Keep terminology consistent across the title, description, headings, and body.
+- Make headings concise and idiomatic in the target language rather than literal copies of English heading structure.
+- Preserve every fact, number, link, limitation, recommendation, and degree of certainty. Do not add commentary, interpretation, praise, or new claims.
+- Before returning JSON, silently reread the target text once more and rewrite every phrase that sounds translated, unnatural, ambiguous, or grammatically awkward to a native reader.
+- Return only the required JSON object and never describe the translation or editing process.`;
 
 const CATEGORY_HINTS = {
   release: (localeLabel) =>
@@ -127,9 +140,9 @@ ${buildCodePlaceholderRequirements(blockCount)}
 
 ${categoryHint}
 
-${GLOSSARY}
+${EDITORIAL_REQUIREMENTS}
 
-${TITLE_EXAMPLE}
+${GLOSSARY}
 
 Category: ${category}
 
@@ -244,7 +257,7 @@ export async function translateNoteToLocale(
       provider: translate.provider,
       title: 'cryptofoundry content translation',
       system:
-        `You are a professional technical translator for a crypto engineering blog. Output strict JSON with title, description, and body fields. The body must be fully translated into the target language. Never translate glossary terms${blocks.length > 0 ? ' or the listed protected code blocks' : ''}.`,
+        'You are a native technical writer, professional translator, and senior editor in the requested target language. Produce accurate, publication-ready prose that does not read like a translation. Preserve all facts and protected technical content. Output strict JSON with title, description, and body fields only.',
     });
 
     return { translated, model: model ?? configuredModel };

--- a/scripts/tests/translate-content.test.mjs
+++ b/scripts/tests/translate-content.test.mjs
@@ -39,9 +39,16 @@ test('does not mention code placeholder tokens when the source has no code block
   });
 
   assert.equal(calls.length, 1);
-  assert.deepEqual(calls[0].options.models, ['qwen/qwen3.7-plus']);
+  assert.deepEqual(calls[0].options.models, ['google/gemini-3.1-flash-lite']);
+  assert.equal(calls[0].options.temperature, 0.4);
   assert.doesNotMatch(calls[0].prompt, /@@CODEBLOCK/);
   assert.doesNotMatch(calls[0].options.system, /@@CODEBLOCK/);
+  assert.match(calls[0].prompt, /Translation and editorial workflow:/);
+  assert.match(calls[0].prompt, /sounds translated, unnatural, ambiguous, or grammatically awkward/);
+  assert.match(calls[0].prompt, /Preserve every fact, number, link, limitation, recommendation, and degree of certainty/);
+  assert.doesNotMatch(calls[0].prompt, /Title translation example:/);
+  assert.match(calls[0].options.system, /native technical writer, professional translator, and senior editor/);
+  assert.match(calls[0].options.system, /does not read like a translation/);
   assert.match(translated, /Русский заголовок/);
   assert.match(translated, /Первый абзац/);
 });
@@ -61,8 +68,8 @@ test('uses the next configured model after a semantic placeholder failure', asyn
   });
 
   assert.equal(calls.length, 2);
-  assert.deepEqual(calls[0].options.models, ['qwen/qwen3.7-plus']);
-  assert.deepEqual(calls[1].options.models, ['deepseek/deepseek-v4-pro']);
+  assert.deepEqual(calls[0].options.models, ['google/gemini-3.1-flash-lite']);
+  assert.deepEqual(calls[1].options.models, ['qwen/qwen3.7-plus']);
   assert.match(calls[1].prompt, /Previous output failed validation: Code placeholder mismatch: unknown 0/);
   assert.doesNotMatch(translated, /@@CODEBLOCK/);
 });
@@ -88,7 +95,7 @@ test('preserves the semantic retry reason across an intermediate transport failu
   });
 
   assert.equal(calls.length, 3);
-  assert.deepEqual(calls[2].options.models, ['qwen/qwen3-235b-a22b-2507']);
+  assert.deepEqual(calls[2].options.models, ['deepseek/deepseek-v4-pro']);
   assert.match(calls[2].prompt, /Previous output failed validation: Code placeholder mismatch: unknown 0/);
   assert.match(translated, /Первый абзац/);
 });
@@ -107,7 +114,7 @@ test('rejects internal placeholders in translated frontmatter fields', async () 
     requestOpenRouter,
   });
 
-  assert.deepEqual(calls, ['qwen/qwen3.7-plus', 'deepseek/deepseek-v4-pro']);
+  assert.deepEqual(calls, ['google/gemini-3.1-flash-lite', 'qwen/qwen3.7-plus']);
   assert.doesNotMatch(translated, /@@codeblock/i);
 });
 
@@ -143,12 +150,12 @@ test('reports every attempted model when all translations fail validation', asyn
 
   await assert.rejects(
     translateNoteToLocale(frontmatter, englishBody, 'ru', { requestOpenRouter }),
-    /Translation failed for translation-fallback-test → ru after qwen\/qwen3\.7-plus, deepseek\/deepseek-v4-pro, qwen\/qwen3-235b-a22b-2507: response title must be a non-empty string/,
+    /Translation failed for translation-fallback-test → ru after google\/gemini-3\.1-flash-lite, qwen\/qwen3\.7-plus, deepseek\/deepseek-v4-pro: response title must be a non-empty string/,
   );
   assert.deepEqual(models, [
+    'google/gemini-3.1-flash-lite',
     'qwen/qwen3.7-plus',
     'deepseek/deepseek-v4-pro',
-    'qwen/qwen3-235b-a22b-2507',
   ]);
 });
 


### PR DESCRIPTION
## Description

- Make `google/gemini-3.1-flash-lite` the primary translation model
- Keep `qwen/qwen3.7-plus` and `deepseek/deepseek-v4-pro` as validation and transport fallbacks
- Raise the translation temperature from `0.3` to `0.4`
- Add the tested universal translation and editorial workflow for natural, publication-ready technical prose across every target locale
- Replace the generic translator system instruction with a native technical writer and senior editor role
- Remove the German-only title example from the universal prompt
- Add regression coverage for the model order, temperature, editorial requirements, and system instruction

The new settings apply only to translations generated after this change. Existing localized Engineering notes are not regenerated.

## Related issue

- Related to #11

## How to test

```bash
npm run validate:config
npm run test:content
npm run lint
npm run validate:notes
npm run build
npm run validate:seo
git diff --check
```

## Risk review

- The prompt explicitly preserves facts, links, technical identifiers, Markdown, and glossary terms
- Existing code block placeholder validation and model fallback behavior remain active
- URL placeholder substitution and exact URL validation are intentionally outside this change and will be monitored through future generated content
- No existing publication, secret, deployment setting, or source state is changed

## Checklist

- [x] Repository artifacts are in English
- [x] The prompt is locale-neutral and applies to all seven translated locales
- [x] Gemini is the primary model and the translation temperature is `0.4`
- [x] Existing publications remain unchanged
- [x] Content, config, notes, lint, build, and SEO validation pass
